### PR TITLE
Adds Tdo.nvim for integrated TODO management

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -340,7 +340,7 @@ Aquí están todos los atajos de teclado definidos para mi configuración de Neo
 | <kbd><leader>ecc</kbd>                | Neovim Configs                                      | [N]             | PickMe defaults (auto)              |
 | <kbd><leader>ecL</kbd>                | Neovim Logs                                         | [N]             | PickMe defaults (auto)              |
 | <kbd><leader>ecP</kbd>                | Neovim Plugins                                      | [N]             | PickMe defaults (auto)              |
-| <kbd><leader>ed</kbd>                 | Home Dirs -> open new Neovim instance at selected directory | [N]             |                                     |
+| <kbd><leader>ed</kbd>                 | Directorios en $HOME -> abrir nueva instancia de Neovim en el directorio seleccionado | [N]             |                                     |
 | <kbd><leader>fa</kbd>                 | Find Files                                          | [N]             | PickMe defaults (auto)              |
 | <kbd><leader>fd</kbd>                 | Project Dirs                                        | [N]             | PickMe defaults (auto)              |
 | <kbd><leader>ff</kbd>                 | Find Git Files                                      | [N]             | PickMe defaults (auto)              |
@@ -354,7 +354,7 @@ Aquí están todos los atajos de teclado definidos para mi configuración de Neo
 | Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
 | ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
 | <kbd><leader>/</kbd>                  | Search History                                      | [N]             | PickMe defaults (auto)              |
-| <kbd><leader>eh</kbd>                 | Custom: search files anywhere in $HOME by name      | [N]             |                                     |
+| <kbd><leader>eh</kbd>                 | Personalizado: buscar archivos en cualquier parte de $HOME por nombre | [N]             |                                     |
 | <kbd><leader>ol</kbd>                 | Search for Plugin Spec                              | [N]             | PickMe defaults (auto)              |
 | <kbd><leader>os</kbd>                 | Search History                                      | [N]             | PickMe defaults (auto)              |
 
@@ -432,6 +432,42 @@ Aquí están todos los atajos de teclado definidos para mi configuración de Neo
 | <kbd><leader>om</kbd>                 | Man Pages                                           | [N]             | PickMe defaults (auto)              |
 | <kbd><leader>on</kbd>                 | Notifications                                       | [N]             | PickMe defaults (auto)              |
 | <kbd><leader>oo</kbd>                 | Options                                             | [N]             | PickMe defaults (auto)              |
+
+
+---
+
+### [lua/plugins/tools/tdo.lua](lua/plugins/tools/tdo.lua)
+
+#### Navegación
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd><leader>ng</kbd>                 | Find Notes                                          | [N]             | Defaults (auto)                     |
+
+#### Archivos/Proyecto
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd><leader>nf</kbd>                 | All Notes                                           | [N]             | Defaults (auto)                     |
+
+#### UI/Tema
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd><leader>nx</kbd>                 | Toggle Todo                                         | [N]             | Defaults (auto)                     |
+
+#### Atajos con <leader>
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd><leader>nc</kbd>                 | Create Note                                         | [N]             | Defaults (auto)                     |
+| <kbd><leader>nt</kbd>                 | Incomplete Todos                                    | [N]             | Defaults (auto)                     |
+
+#### Otros
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd>README.md</kbd>                  | todos.sh                                            | [N]             | Defaults (auto)                     |
 
 
 ---

--- a/lua/plugins/list.lua
+++ b/lua/plugins/list.lua
@@ -114,7 +114,13 @@ local plugins = {
         cmd = 'UtilsClearCache',
     },
 
-
+        -- Gestor de TODOs integrado
+    {
+        '2kabhishek/tdo.nvim',
+        cmd = { 'Tdo' },
+        keys = { '<leader>nn', '<leader>nt', '<leader>nx', '[t', ']t' },
+        config = load_config('tools.tdo'),
+    },
     {
         -- Terminal integrado mejorado
         '2kabhishek/termim.nvim',

--- a/lua/plugins/lock.json
+++ b/lua/plugins/lock.json
@@ -9,6 +9,7 @@
   "pickme.nvim": { "branch": "main", "commit": "55ca0f1889ea2a4df4b45c77941327a590e025c5" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "snacks.nvim": { "branch": "main", "commit": "bc0630e43be5699bb94dadc302c0d21615421d93" },
+  "tdo.nvim": { "branch": "main", "commit": "025bbdb74743b61a4a5275e6cf17fc6c09410517" },
   "termim.nvim": { "branch": "main", "commit": "e4bcf977bef6f6c79996e38fcb9faeccd912007c" },
   "utils.nvim": { "branch": "main", "commit": "8950622bd6861f2257364e5027c5613f29225e17" },
   "which-key.nvim": { "branch": "main", "commit": "370ec46f710e058c9c1646273e6b225acf47cbed" }

--- a/lua/plugins/tools/tdo.lua
+++ b/lua/plugins/tools/tdo.lua
@@ -1,0 +1,114 @@
+-- ╔══════════════════════════════════════════════════════════════════════╗
+-- ║ tdo.lua: Configuración de la herramienta de gestión de tareas        ║
+-- ║ Este archivo es invocado desde 'init.lua'                            ║
+-- ║                                                                      ║
+-- ║ Este archivo define y documenta la configuración de la herramienta   ║
+-- ║ de gestión de tareas, permitiendo personalizar el comportamiento y   ║
+-- ║ la integración con otras herramientas.                               ║
+-- ║                                                                      ║
+-- ╚══════════════════════════════════════════════════════════════════════╝
+
+-- Requiere el módulo principal de la herramienta de gestión de tareas
+local tdo = require('tdo')
+
+-- Configura la herramienta de gestión de tareas con las siguientes opciones:
+tdo.setup({
+    -- Habilita el uso de un nuevo comando para gestionar tareas
+    use_new_command = true,
+    -- Añade los atajos de teclado predeterminados para la herramienta
+    add_default_keybindings = true,
+    -- Configuración de la caché para mejorar el rendimiento
+    cache = {
+        -- Tiempo de expiración de la caché en milisegundos
+        timeout = 5000,
+        -- Número máximo de entradas que se pueden almacenar en la caché
+        max_entries = 100,
+    },
+    -- Opciones relacionadas con la autocompletación de tareas
+    completion = {
+        -- Desplazamientos personalizados para la autocompletación (vacío por defecto)
+        offsets = {},
+        -- Archivos y carpetas que serán ignorados por la autocompletación
+        ignored_files = { 'README.md', 'templates', 'todos.sh' },
+    },
+})
+
+
+-- local function add_default_keymaps()
+--     local mappings = {
+--         { '<leader>nn', ':Tdo<CR>', "Today's Todo" },
+--         { '<leader>ne', ':Tdo entry<CR>', "Today's Entry" },
+--         { '<leader>nf', ':Tdo files<CR>', 'All Notes' },
+--         { '<leader>ng', ':Tdo find<CR>', 'Find Notes' },
+--         { '<leader>nh', ':Tdo yesterday<CR>', "Yesterday's Todo" },
+--         { '<leader>nl', ':Tdo tomorrow<CR>', "Tomorrow's Todo" },
+--         { '<leader>nc', ':Tdo note<CR>', 'Create Note' },
+--         { '<leader>nt', ':Tdo todos<CR>', 'Incomplete Todos' },
+--         { '<leader>nx', ':Tdo toggle<CR>', 'Toggle Todo' },
+
+--         { ']t', [[/\v\[ \]\_s*[^[]<CR>:noh<CR>]], 'Next Todo' },
+--         { '[t', [[?\v\[ \]\_s*[^[]<CR>:noh<CR>]], 'Prev Todo' },
+--     }
+
+--     table.insert(mappings, {
+--         '<leader>ns',
+--         ':lua require("tdo.notes").run_with("commit " .. vim.fn.expand("%:p")) vim.notify("Tdo Committed!")<CR>',
+--         'Commit Note',
+--     })
+
+--     for i = 1, 9 do
+--         table.insert(mappings, {
+--             string.format('<leader>nd%d', i),
+--             string.format(':Tdo %d<CR>', i),
+--             string.format('Todo %d Days Later', i),
+--         })
+
+--         table.insert(mappings, {
+--             string.format('<leader>nD%d', i),
+--             string.format(':Tdo -%d<CR>', i),
+--             string.format('Todo %d Days Ago', i),
+--         })
+
+--         table.insert(mappings, {
+--             string.format('<leader>nw%d', i),
+--             string.format(':Tdo %d-weeks-later<CR>', i),
+--             string.format('Todo %d Weeks Later', i),
+--         })
+
+--         table.insert(mappings, {
+--             string.format('<leader>nW%d', i),
+--             string.format(':Tdo %d-weeks-ago<CR>', i),
+--             string.format('Todo %d Weeks Ago', i),
+--         })
+
+--         table.insert(mappings, {
+--             string.format('<leader>nm%d', i),
+--             string.format(':Tdo %d-months-later<CR>', i),
+--             string.format('Todo %d Months Later', i),
+--         })
+
+--         table.insert(mappings, {
+--             string.format('<leader>nM%d', i),
+--             string.format(':Tdo %d-months-ago<CR>', i),
+--             string.format('Todo %d Months Ago', i),
+--         })
+
+--         table.insert(mappings, {
+--             string.format('<leader>ny%d', i),
+--             string.format(':Tdo %d-years-later<CR>', i),
+--             string.format('Todo %d Years Later', i),
+--         })
+
+--         table.insert(mappings, {
+--             string.format('<leader>nY%d', i),
+--             string.format(':Tdo %d-years-ago<CR>', i),
+--             string.format('Todo %d Years Ago', i),
+--         })
+--     end
+
+
+-- ╔═════════════════════════════════════════════════════╗
+-- ║                                                     ║
+-- ║              Roberto Flores - Nvim                  ║
+-- ║                                                     ║
+-- ╚═════════════════════════════════════════════════════╝


### PR DESCRIPTION
Adds `tdo.nvim` to enable integrated TODO management within Neovim.

- Includes configuration for the plugin with default settings and keybindings.
- Updates the keybindings documentation to reflect the new TODO management shortcuts.
- The new plugin provides functionalities for creating, navigating, and toggling TODO items.