### PR TITLE
Adds new plugins and keybindings

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -148,6 +148,7 @@ Aquí están todos los atajos de teclado definidos para mi configuración de Neo
 
 | Keybinding                         | Action         |
 | ---------------------------------- | -------------- |
+| <kbd>Leader</kbd> <kbd> g C </kbd> | Co-Authors |
 
 ### i -  Insert
 
@@ -291,6 +292,23 @@ Aquí están todos los atajos de teclado definidos para mi configuración de Neo
 | <kbd><leader>exl</kbd>                | List Default Language Exercises                     | [N]             | Exercism defaults (auto)            |
 | <kbd><leader>exs</kbd>                | Submit Exercise                                     | [N]             | Exercism defaults (auto)            |
 | <kbd><leader>ext</kbd>                | Test Exercise                                       | [N]             | Exercism defaults (auto)            |
+
+
+---
+
+### [lua/plugins/tools/nerdy.lua](lua/plugins/tools/nerdy.lua)
+
+#### Archivos/Proyecto
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd><leader>iN</kbd>                 | Nerdy: Recent Icons                                 | [N]             | Nerdy defaults (auto)               |
+
+#### Atajos con <leader>
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd><leader>in</kbd>                 | Nerdy: List Icons                                   | [N]             | Nerdy defaults (auto)               |
 
 
 ---

--- a/lua/plugins/list.lua
+++ b/lua/plugins/list.lua
@@ -91,7 +91,6 @@ local plugins = {
      -- ═════════════════════════════════════════════════════════════════════════
     -- 🏠 CATEGORIA: HOMEGROWN (PLUGINS DE 2KABHISHEK)
     -- ═════════════════════════════════════════════════════════════════════════
-    -- Plugins desarrollados específicamente por el autor de nvim2k
     {
         -- Selector genérico con soporte para múltiples proveedores
         '2kabhishek/pickme.nvim',
@@ -105,15 +104,35 @@ local plugins = {
         opts = {
             picker_provider = 'snacks',
         },
-        config = load_config('tools.pickme'),
     },
-    
+
     {
         -- Utilidades compartidas para plugins de 2kabhishek
         '2kabhishek/utils.nvim',
         cmd = 'UtilsClearCache',
     },
 
+    {
+        -- Manejo de co-autores en commits
+        '2kabhishek/co-author.nvim',
+        cmd = 'CoAuthor',
+    },
+
+    {
+        -- Selector de iconos y caracteres especiales
+        '2kabhishek/nerdy.nvim',
+        cmd = { 'Nerdy' },
+        keys = { '<leader>in', '<leader>iN' },
+        config = load_config('tools.nerdy'),
+    },
+
+    {
+        -- Terminal integrado mejorado
+        '2kabhishek/termim.nvim',
+        cmd = { 'Fterm', 'FTerm', 'Sterm', 'STerm', 'Vterm', 'VTerm' },
+    },
+
+    {
         -- Gestor de TODOs integrado
     {
         '2kabhishek/tdo.nvim',
@@ -121,10 +140,16 @@ local plugins = {
         keys = { '<leader>nn', '<leader>nt', '<leader>nx', '[t', ']t' },
         config = load_config('tools.tdo'),
     },
+
     {
-        -- Terminal integrado mejorado
-        '2kabhishek/termim.nvim',
-        cmd = { 'Fterm', 'FTerm', 'Sterm', 'STerm', 'Vterm', 'VTerm' },
+        -- Integración con GitHub para gestión de repositorios
+        '2kabhishek/octohub.nvim',
+        cmd = { 'Octohub' },
+        keys = { '<leader>goo' },
+        dependencies = {
+            '2kabhishek/utils.nvim',
+        },
+        config = load_config('tools.octohub'),
     },
 
     {
@@ -139,20 +164,19 @@ local plugins = {
         config = load_config('tools.exercism'),
     },
 
-    {
-        {
-            -- Integración con GitHub para gestión de repositorios
-            '2kabhishek/octohub.nvim',
-            cmd = { 'Octohub' },
-            keys = { '<leader>goo' },
-            dependencies = {
-                '2kabhishek/utils.nvim',
-            },
-            config = load_config('tools.octohub'),
-        },
+    -- Plugin de template comentado para desarrollo
+    -- {
+    --     '2kabhishek/template.nvim',
+    --     cmd = { 'Template' },
+    --     keys = { 'th' },
+    --     dependencies = { '2kabhishek/utils.nvim', },
+    --     config = load_config('tools.template'),
+    --     opts = {},
+    --     dir = '~/Projects/2KAbhishek/exercism.nvim/',
+    -- },
     
-    },
-    
+}
+
 }
 -- ──────────────────────────────────────────────────────────────────────────────
 -- 📤 EXPORTACIÓN DE CONFIGURACIÓN

--- a/lua/plugins/lock.json
+++ b/lua/plugins/lock.json
@@ -1,8 +1,10 @@
 {
+  "co-author.nvim": { "branch": "main", "commit": "2f012714247dfe1959ba53fa50e4b1320d86d1b8" },
   "exercism.nvim": { "branch": "main", "commit": "7cb452432dcc0168ab3b246b0339b97b06408fef" },
   "gitlinker.nvim": { "branch": "master", "commit": "cc59f732f3d043b626c8702cb725c82e54d35c25" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
   "lualine.nvim": { "branch": "master", "commit": "b8c23159c0161f4b89196f74ee3a6d02cdc3a955" },
+  "nerdy.nvim": { "branch": "main", "commit": "a8e3f70dc0232e956adfb12c647b7e9e2b2e6c89" },
   "nvim-web-devicons": { "branch": "master", "commit": "6e51ca170563330e063720449c21f43e27ca0bc1" },
   "octohub.nvim": { "branch": "main", "commit": "03b50d28a61583387616c04ba08cee53379049b2" },
   "onedark.nvim": { "branch": "master", "commit": "de495fabe171d48aed5525f002d14414efcecbb2" },

--- a/lua/plugins/tools/nerdy.lua
+++ b/lua/plugins/tools/nerdy.lua
@@ -1,0 +1,36 @@
+-- ╔════════════════════════════════════════════════════════╗
+-- ║ nerdy.lua: Configuración del plugin de selección de    ║
+-- ║ iconos y caracteres especiales                         ║
+-- ║ Este archivo es invocado desde 'init.lua'              ║
+-- ║                                                        ║
+-- ║ Este archivo define y documenta la configuración del   ║
+-- ║ plugin de selección de iconos y caracteres especiales, ║
+-- ║ permitiendo personalizar el comportamiento y la        ║
+-- ║ integración con otras herramientas.                    ║
+-- ║                                                        ║
+-- ╚════════════════════════════════════════════════════════╝
+
+
+-- Requiere el módulo principal del plugin 'nerdy'
+local nerdy = require('nerdy')
+
+-- Configuración del plugin 'nerdy'
+nerdy.setup({
+    max_recents = 80,                -- Número máximo de iconos/caracteres recientes a recordar
+    add_default_keybindings = true,  -- Habilita los atajos de teclado predeterminados
+    use_new_command = true,          -- Usa el nuevo comando para abrir el selector
+})
+
+-- function M.setup()
+--     add_nerdy_command()
+--     if config.add_default_keybindings then
+--         vim.api.nvim_set_keymap('n', '<leader>in', ':Nerdy list<CR>', { noremap = true, silent = true })
+--         vim.api.nvim_set_keymap('n', '<leader>iN', ':Nerdy recents<CR>', { noremap = true, silent = true })
+--     end
+-- end
+
+-- ╔═════════════════════════════════════════════════════╗
+-- ║                                                     ║
+-- ║              Roberto Flores - Nvim                  ║
+-- ║                                                     ║
+-- ╚═════════════════════════════════════════════════════╝

--- a/lua/plugins/ui/which-key.lua
+++ b/lua/plugins/ui/which-key.lua
@@ -91,7 +91,12 @@ local normal_mappings = {
 
     { '<leader>f', group = ' Find' },
 
+    
+
+
     { '<leader>g', group = ' Git' },
+    { '<leader>gC', ':CoAuthor<cr>', desc = 'Co-Authors' },
+
 
     { '<leader>i', group = ' Insert' },
 


### PR DESCRIPTION
Adds several new plugins by 2kabhishek:

- `co-author.nvim` for managing co-authors in commits
- `nerdy.nvim` for icon and special character selection
- `termim.nvim` for an improved integrated terminal
- `octohub.nvim` for GitHub repository management
- Updates keybindings documentation to reflect new `co-author` keybinding
- Adds `nerdy.lua` configuration file.