### PR TITLE
Adds Markit plugin and keybinding documentation

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -508,6 +508,48 @@ Aquí están todos los atajos de teclado definidos para mi configuración de Neo
 
 ---
 
+### [lua/plugins/ui/markit.lua](lua/plugins/ui/markit.lua)
+
+#### Ventanas/Buffers/Tabs
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd><leader>mD</kbd>                 | Delete Marks In Buffer                              | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mM</kbd>                 | Buffer Marks                                        | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mqM</kbd>                | Buffer Marks → QuickFix                             | [N]             | Defaults (auto); Markit defaults (auto) |
+
+#### UI/Tema
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd><leader>mqb</kbd>                | All Bookmarks → QuickFix                            | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mqg</kbd>                | All Marks → QuickFix                                | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mqm</kbd>                | All Marks → QuickFix                                | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mt</kbd>                 | Toggle Mark at Cursor                               | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mT</kbd>                 | Toggle Mark (Interactive)                           | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mv</kbd>                 | Toggle Signs                                        | [N]             | Defaults (auto); Markit defaults (auto) |
+
+#### Atajos con <leader>
+
+| Combinación de teclas                 | Acción (Español)                                    | Modo(s)         | Contexto/Notas                   |
+| ------------------------------------- | --------------------------------------------------- | --------------- | ----------------------------------- |
+| <kbd><leader>ma</kbd>                 | Annotate Bookmark                                   | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mb</kbd>                 | All Bookmarks                                       | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>md</kbd>                 | Delete Marks In Line                                | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mh</kbd>                 | Previous Bookmark                                   | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mj</kbd>                 | Next Mark                                           | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mk</kbd>                 | Previous Mark                                       | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>ml</kbd>                 | Next Bookmark                                       | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mm</kbd>                 | All Marks                                           | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mP</kbd>                 | Preview Mark                                        | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>ms</kbd>                 | Set Next Available Mark                             | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mS</kbd>                 | Set Mark (Interactive)                              | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mX</kbd>                 | Delete Mark (Interactive)                           | [N]             | Defaults (auto); Markit defaults (auto) |
+| <kbd><leader>mx</kbd>                 | Delete Bookmark at Cursor                           | [N]             | Defaults (auto); Markit defaults (auto) |
+
+
+---
+
 ### [lua/plugins/ui/onedark.lua](lua/plugins/ui/onedark.lua)
 
 #### UI/Tema

--- a/lua/plugins/list.lua
+++ b/lua/plugins/list.lua
@@ -44,13 +44,13 @@ local plugins = {
         -- Tema principal OneDark con configuración personalizada
         'navarasu/onedark.nvim',
         config = load_config('ui.onedark'),
-        lazy = false,        -- Se carga inmediatamente
-        priority = 1000,     -- Alta prioridad para evitar parpadeos
+        lazy = false, -- Se carga inmediatamente
+        priority = 1000, -- Alta prioridad para evitar parpadeos
     },
 
     {
         -- Iconos web para mejorar la visualización de archivos
-        'nvim-tree/nvim-web-devicons'
+        'nvim-tree/nvim-web-devicons',
     },
 
     {
@@ -83,11 +83,17 @@ local plugins = {
         event = { 'BufReadPost', 'BufNewFile' },
     },
 
-  -- ═════════════════════════════════════════════════════════════════════════
+    {
+        '2kabhishek/markit.nvim',
+        config = load_config('ui.markit'),
+        event = { 'BufReadPost', 'BufNewFile' },
+    },
+
+    -- ═════════════════════════════════════════════════════════════════════════
     -- 🛠️ CATEGORIA: TOOLS (HERRAMIENTAS GENERALES)
     -- ═════════════════════════════════════════════════════════════════════════
     -- Utilidades y herramientas para productividad
-   
+
     {
         -- Generación de enlaces de Git para compartir código
         'ruifm/gitlinker.nvim',
@@ -101,7 +107,7 @@ local plugins = {
         'tpope/vim-fugitive',
         cmd = 'Git',
     },
-     -- ═════════════════════════════════════════════════════════════════════════
+    -- ═════════════════════════════════════════════════════════════════════════
     -- 🏠 CATEGORIA: HOMEGROWN (PLUGINS DE 2KABHISHEK)
     -- ═════════════════════════════════════════════════════════════════════════
     {
@@ -147,49 +153,47 @@ local plugins = {
 
     {
         -- Gestor de TODOs integrado
-    {
-        '2kabhishek/tdo.nvim',
-        cmd = { 'Tdo' },
-        keys = { '<leader>nn', '<leader>nt', '<leader>nx', '[t', ']t' },
-        config = load_config('tools.tdo'),
-    },
-
-    {
-        -- Integración con GitHub para gestión de repositorios
-        '2kabhishek/octohub.nvim',
-        cmd = { 'Octohub' },
-        keys = { '<leader>goo' },
-        dependencies = {
-            '2kabhishek/utils.nvim',
+        {
+            '2kabhishek/tdo.nvim',
+            cmd = { 'Tdo' },
+            keys = { '<leader>nn', '<leader>nt', '<leader>nx', '[t', ']t' },
+            config = load_config('tools.tdo'),
         },
-        config = load_config('tools.octohub'),
-    },
 
-    {
-        -- Integración con Exercism para práctica de programación
-        '2kabhishek/exercism.nvim',
-        cmd = { 'Exercism' },
-        keys = { '<leader>exa', '<leader>exl', '<leader>exr' },
-        dependencies = {
-            '2kabhishek/utils.nvim',
-            '2kabhishek/termim.nvim',
+        {
+            -- Integración con GitHub para gestión de repositorios
+            '2kabhishek/octohub.nvim',
+            cmd = { 'Octohub' },
+            keys = { '<leader>goo' },
+            dependencies = {
+                '2kabhishek/utils.nvim',
+            },
+            config = load_config('tools.octohub'),
         },
-        config = load_config('tools.exercism'),
+
+        {
+            -- Integración con Exercism para práctica de programación
+            '2kabhishek/exercism.nvim',
+            cmd = { 'Exercism' },
+            keys = { '<leader>exa', '<leader>exl', '<leader>exr' },
+            dependencies = {
+                '2kabhishek/utils.nvim',
+                '2kabhishek/termim.nvim',
+            },
+            config = load_config('tools.exercism'),
+        },
+
+        -- Plugin de template comentado para desarrollo
+        -- {
+        --     '2kabhishek/template.nvim',
+        --     cmd = { 'Template' },
+        --     keys = { 'th' },
+        --     dependencies = { '2kabhishek/utils.nvim', },
+        --     config = load_config('tools.template'),
+        --     opts = {},
+        --     dir = '~/Projects/2KAbhishek/exercism.nvim/',
+        -- },
     },
-
-    -- Plugin de template comentado para desarrollo
-    -- {
-    --     '2kabhishek/template.nvim',
-    --     cmd = { 'Template' },
-    --     keys = { 'th' },
-    --     dependencies = { '2kabhishek/utils.nvim', },
-    --     config = load_config('tools.template'),
-    --     opts = {},
-    --     dir = '~/Projects/2KAbhishek/exercism.nvim/',
-    -- },
-    
-}
-
 }
 -- ──────────────────────────────────────────────────────────────────────────────
 -- 📤 EXPORTACIÓN DE CONFIGURACIÓN

--- a/lua/plugins/ui/markit.lua
+++ b/lua/plugins/ui/markit.lua
@@ -1,0 +1,72 @@
+-- ╔══════════════════════════════════════════════════════════════════════╗
+-- ║ markit.lua: Configuración y documentación del plugin Markit         ║
+-- ║ Este archivo es invocado desde la configuración de plugins          ║
+-- ║                                                                    ║
+-- ║ Aquí se definen las opciones principales para el plugin Markit,     ║
+-- ║ permitiendo personalizar el manejo de marcas y bookmarks en Neovim. ║
+-- ║ Se establecen valores predeterminados para iconos, prioridades,     ║
+-- ║ exclusiones y tipos de bookmarks, adaptando la experiencia de uso   ║
+-- ║ a flujos de trabajo modernos y eficientes.                          ║
+-- ║                                                                    ║
+-- ╚══════════════════════════════════════════════════════════════════════╝
+
+-- Requiere el módulo principal del plugin 'markit'
+local markit = require('markit')
+local icons = require('lib.icons')
+
+-- Configuración principal del plugin 'markit'
+markit.setup({
+    add_default_keybindings = true,
+    builtin_marks = { '.', '<', '>', '^' },
+    cyclic = true,
+    force_write_shada = false,
+    sign_priority = { lower = 10, upper = 15, builtin = 8, bookmark = 20 },
+    excluded_filetypes = {},
+    excluded_buftypes = { 'nofile' },
+    bookmarks = {
+        { sign = icons.ui.Neovim, virt_text = 'flag', annotate = false },
+        { sign = icons.ui.Eye, virt_text = 'watch', annotate = false },
+        { sign = icons.ui.Star, virt_text = 'star', annotate = false },
+        { sign = icons.ui.Bug, virt_text = 'bug', annotate = false },
+    },
+})
+
+
+-- local function setup_default_keybindings(config)
+--     local mappings = {
+--         { '<leader>mm', ':Markit mark list all<cr>', 'All Marks' },
+--         { '<leader>mM', ':Markit mark list buffer<cr>', 'Buffer Marks' },
+--         { '<leader>ms', ':Markit mark set<cr>', 'Set Next Available Mark' },
+--         { '<leader>mS', ':Markit mark set<cr>', 'Set Mark (Interactive)' },
+--         { '<leader>mt', ':Markit mark toggle<cr>', 'Toggle Mark at Cursor' },
+--         { '<leader>mT', ':Markit mark toggle<cr>', 'Toggle Mark (Interactive)' },
+
+--         { '<leader>mj', ':Markit mark next<cr>', 'Next Mark' },
+--         { '<leader>mk', ':Markit mark prev<cr>', 'Previous Mark' },
+--         { '<leader>mP', ':Markit mark preview<cr>', 'Preview Mark' },
+
+--         { '<leader>md', ':Markit mark delete line<cr>', 'Delete Marks In Line' },
+--         { '<leader>mD', ':Markit mark delete buffer<cr>', 'Delete Marks In Buffer' },
+--         { '<leader>mX', ':Markit mark delete<cr>', 'Delete Mark (Interactive)' },
+
+--         { '<leader>mb', ':Markit bookmark list all<cr>', 'All Bookmarks' },
+--         { '<leader>mx', ':Markit bookmark delete<cr>', 'Delete Bookmark at Cursor' },
+--         { '<leader>ma', ':Markit bookmark annotate<cr>', 'Annotate Bookmark' },
+
+--         { '<leader>ml', ':Markit bookmark next<cr>', 'Next Bookmark' },
+--         { '<leader>mh', ':Markit bookmark prev<cr>', 'Previous Bookmark' },
+
+--         { '<leader>mv', ':Markit bookmark signs<cr>', 'Toggle Signs' },
+
+--         { '<leader>mqm', ':Markit mark list quickfix all<cr>', 'All Marks → QuickFix' },
+--         { '<leader>mqb', ':Markit bookmark list quickfix all<cr>', 'All Bookmarks → QuickFix' },
+--         { '<leader>mqM', ':Markit mark list quickfix buffer<cr>', 'Buffer Marks → QuickFix' },
+--         { '<leader>mqg', ':Markit mark list quickfix all<cr>', 'All Marks → QuickFix' },
+--     }
+
+
+-- ╔═════════════════════════════════════════════════════╗
+-- ║                                                     ║
+-- ║              Roberto Flores - Nvim                  ║
+-- ║                                                     ║
+-- ╚═════════════════════════════════════════════════════╝

--- a/lua/plugins/ui/which-key.lua
+++ b/lua/plugins/ui/which-key.lua
@@ -105,6 +105,10 @@ local normal_mappings = {
     { '<leader>l', group = ' LSP' },
 
     { '<leader>m', group = ' Marks' },
+    { '<leader>mg', group = 'Group Bookmarks' },
+    { '<leader>mG', group = 'Group Bookmarks In Project' },
+    { '<leader>mn', group = 'Next Bookmark In Group' },
+    { '<leader>mp', group = 'Previous Bookmark In Group' },
 
     { '<leader>n', group = ' Notes' },
 


### PR DESCRIPTION
Adds the `markit.nvim` plugin for enhanced mark management.

- Includes plugin configuration and default keybindings.
- Updates keybinding documentation in `keybindings.md` to reflect new Markit shortcuts.
- Integrates Markit into the plugin list.